### PR TITLE
Add max size handling of mesages

### DIFF
--- a/lib/logstash/outputs/sqs.rb
+++ b/lib/logstash/outputs/sqs.rb
@@ -127,7 +127,6 @@ class LogStash::Outputs::SQS < LogStash::Outputs::Base
     message_body = event.to_json
     if message_body.bytesize > @message_max_size
       @logger.warn("Message exceeds max length and will be dropped. Max Bytes: #{@message_max_size}, Total Bytes: #{message_body.bytesize}.")
-      event.cancel
       return
     end
 

--- a/lib/logstash/outputs/sqs.rb
+++ b/lib/logstash/outputs/sqs.rb
@@ -77,6 +77,12 @@ class LogStash::Outputs::SQS < LogStash::Outputs::Base
   # If `batch` is set to true, the maximum amount of time between `batch_send` commands when there are pending events to flush.
   config :batch_timeout, :validate => :number, :default => 5
 
+  # The maximum number of bytes for any message sent to SQS. Messages exceeding this value will get truncated.
+  config :message_max_size, :validate => :number, :default => (256 * 1024)
+
+  # If true the logstash will give up if SQS throws an exception. Default is to retry ad infinum.
+  config :stop_on_fail, :validate => :boolean, :default => false
+
   public
   def aws_service_endpoint(region)
     return {
@@ -118,16 +124,34 @@ class LogStash::Outputs::SQS < LogStash::Outputs::Base
 
   public
   def receive(event)
-    if @batch
-      buffer_receive(event.to_json)
+    message_body = event.to_json
+    if message_body.bytesize > @message_max_size
+      @logger.warn("Message exceeds max length and will be dropped. Max Bytes: #{@message_max_size}, Total Bytes: #{message_body.bytesize}.")
+      event.cancel
       return
     end
-    @sqs_queue.send_message(event.to_json)
+
+    begin
+      if @batch
+        buffer_receive(message_body)
+        return
+      end
+      @sqs_queue.send_message(message_body)
+    rescue Exception => e
+      @logger.error("Unable to log message '#{@message_body}': #{e.to_s}")
+    end
   end # def receive
 
   # called from Stud::Buffer#buffer_flush when there are events to flush
   def flush(events, teardown=false)
     @sqs_queue.batch_send(events)
+  end
+
+  # called from Stud::Buffer#buffer_flush when there are errors while flushing
+  def on_flush_error(error)
+    if (@stop_on_fail)
+      raise error
+    end
   end
 
   public

--- a/logstash-output-sqs.gemspec
+++ b/logstash-output-sqs.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-sqs'
-  s.version         = '0.1.3.a.1'
+  s.version         = '0.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to an Amazon Web Services Simple Queue Service (SQS) queue."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-sqs.gemspec
+++ b/logstash-output-sqs.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-sqs'
-  s.version         = '0.1.3'
+  s.version         = '0.1.3.a.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to an Amazon Web Services Simple Queue Service (SQS) queue."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Adds a setting (message_max_size) to drop all messages that exceed this size. This setting defaults to 256kb because SQS will reject any message over 256kb in size.  

Adds a setting (stop_on_fail) that prevents stud/buffer from forcing infinite retries when SQS rejects a message. Defaults to false, but it should probably default to true in order to avoid racking up infinite SQS charges. Another strategy would be to specify a max number of retries and default that to a reasonable number.
