### PR TITLE
Remove finished and we don't need to explicitely set the @sqs to nil, the gc will take care of it.

### DIFF
--- a/lib/logstash/outputs/sqs.rb
+++ b/lib/logstash/outputs/sqs.rb
@@ -133,7 +133,5 @@ class LogStash::Outputs::SQS < LogStash::Outputs::Base
   public
   def teardown
     buffer_flush(:final => true)
-    @sqs_queue = nil
-    finished
   end # def teardown
 end


### PR DESCRIPTION
Ref https://github.com/elastic/logstash/pull/3812
