### PR TITLE
Major rewrite for new concurrency model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.0.0
+  - Add unit and integration tests.
+  - Adjust the sample IAM policy in the documentation, removing actions which are not actually required by the plugin. Specifically, the following actions are not required: `sqs:ChangeMessageVisibility`, `sqs:ChangeMessageVisibilityBatch`, `sqs:GetQueueAttributes` and `sqs:ListQueues`.
+  - Dynamically adjust the batch message size. SQS allows up to 10 messages to be published in a single batch, however the total size of the batch is limited to 256KiB (see [Limits in Amazon SQS](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/limits-messages.html)). This plugin will now dynamically adjust the number of events included in each batch to ensure that the total batch size does not exceed `message_max_size`. Note that any single messages which exceeds the 256KiB size limit will be dropped.
+  - Move to the new concurrency model, `:shared`.
+  - The `batch_timeout` parameter has been deprecated because it no longer has any effect.
+  - The individual (non-batch) mode of operation (i.e. `batch => false`) has been deprecated. Batch mode is vastly more performant and we do not believe that there are any use cases which require non-batch mode. You can emulate non-batch mode by setting `batch_events => 1`, although this will call `sqs:SendMessageBatch` with a batch size of 1 rather than calling `sqs:SendMessage`.
+  - The plugin now implements `#multi_receive_encoded` and no longer uses `Stud::Buffer`.
+  - Update the AWS SDK to version 2.
+
 ## 3.0.2
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 
@@ -13,7 +23,7 @@
 # 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,12 +6,13 @@ Contributors:
 * James Turnbull (jamtur01)
 * John Price (awesometown)
 * Jordan Sissel (jordansissel)
+* Joshua Spence (joshuaspence)
+* Jurgens du Toit (jrgns)
 * Kurt Hurtado (kurtado)
 * Pier-Hugues Pellerin (ph)
 * Richard Pijnenburg (electrical)
 * Sean Laurent (organicveggie)
 * Toby Collier (tobyw4n)
-* Jurgens du Toit (jrgns)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/outputs/sqs.rb
+++ b/lib/logstash/outputs/sqs.rb
@@ -80,8 +80,8 @@ class LogStash::Outputs::SQS < LogStash::Outputs::Base
   # `batch_events`.
   config :batch, :validate => :boolean, :default => true, :deprecated => true
 
-  # The number of events to be sent in each batch. This is only relevant when
-  # `batch` is set to `true`.
+  # The number of events to be sent in each batch. Set this to `1` to disable
+  # the batch sending of messages.
   config :batch_events, :validate => :number, :default => 10
 
   config :batch_timeout, :validate => :number, :deprecated => 'This setting no longer has any effect.'
@@ -91,7 +91,8 @@ class LogStash::Outputs::SQS < LogStash::Outputs::Base
   # http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/limits-messages.html.
   config :message_max_size, :validate => :bytes, :default => '256KiB'
 
-  # The name of the target SQS queue.
+  # The name of the target SQS queue. Note that this is just the name of the
+  # queue, not the URL or ARN.
   config :queue, :validate => :string, :required => true
 
   public
@@ -116,7 +117,7 @@ class LogStash::Outputs::SQS < LogStash::Outputs::Base
 
   public
   def multi_receive_encoded(encoded_events)
-    if @batch
+    if @batch and @batch_events > 1
       multi_receive_encoded_batch(encoded_events)
     else
       multi_receive_encoded_single(encoded_events)

--- a/lib/logstash/outputs/sqs/patch.rb
+++ b/lib/logstash/outputs/sqs/patch.rb
@@ -1,0 +1,21 @@
+# This patch was stolen from logstash-plugins/logstash-output-s3#102.
+#
+# This patch is a workaround for a JRuby issue which has been fixed in JRuby
+# 9000, but not in JRuby 1.7. See https://github.com/jruby/jruby/issues/3645
+# and https://github.com/jruby/jruby/issues/3920. This is necessary because the
+# `aws-sdk` is doing tricky name discovery to generate the correct error class.
+#
+# As per https://github.com/aws/aws-sdk-ruby/issues/1301#issuecomment-261115960,
+# this patch may be short-lived anyway.
+require 'aws-sdk'
+
+begin
+  old_stderr = $stderr
+  $stderr = StringIO.new
+
+  module Aws
+    const_set(:SQS, Aws::SQS)
+  end
+ensure
+  $stderr = old_stderr
+end

--- a/logstash-output-sqs.gemspec
+++ b/logstash-output-sqs.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-sqs'
-  s.version         = '3.0.2'
+  s.version         = '4.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to an Amazon Web Services Simple Queue Service (SQS) queue."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,12 +20,10 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-aws", ">= 1.0.0"
+  s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
+  s.add_runtime_dependency 'logstash-mixin-aws', '>= 1.0.0'
 
-  s.add_runtime_dependency 'aws-sdk'
-  s.add_runtime_dependency 'stud'
-
+  s.add_development_dependency 'logstash-codec-json'
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/spec/integration/outputs/sqs_spec.rb
+++ b/spec/integration/outputs/sqs_spec.rb
@@ -1,0 +1,92 @@
+# encoding: utf-8
+
+require_relative '../../spec_helper'
+require 'logstash/event'
+require 'logstash/json'
+require 'securerandom'
+
+describe LogStash::Outputs::SQS, :integration => true do
+  let(:config) do
+    {
+      'queue' => @queue_name,
+    }
+  end
+  subject { described_class.new(config) }
+
+  # Create an SQS queue with a random name.
+  before(:all) do
+    @sqs = Aws::SQS::Client.new
+    @queue_name = "logstash-output-sqs-#{SecureRandom.hex}"
+    @queue_url = @sqs.create_queue(:queue_name => @queue_name)[:queue_url]
+  end
+
+  # Destroy the SQS queue which was created in `before(:all)`.
+  after(:all) do
+    @sqs.delete_queue(:queue_url => @queue_url)
+  end
+
+  describe '#register' do
+    context 'with invalid credentials' do
+      let(:config) do
+        super.merge({
+          'access_key_id' => 'bad_access',
+          'secret_access_key' => 'bad_secret_key',
+        })
+      end
+
+      it 'raises a configuration error' do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+
+    context 'with a nonexistent queue' do
+      let(:config) { super.merge('queue' => 'nonexistent-queue') }
+
+      it 'raises a configuration error' do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+
+    context 'with valid configuration' do
+      it 'does not raise an error' do
+        expect { subject.register }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#multi_receive_encoded' do
+    let(:sample_count) { 10 }
+    let(:sample_event) { LogStash::Event.new('message' => 'This is a message') }
+    let(:sample_events) do
+      sample_count.times.map do
+        [sample_event, LogStash::Json.dump(sample_event)]
+      end
+    end
+
+    before do
+      subject.register
+    end
+
+    after do
+      subject.close
+    end
+
+    context 'with batching disabled' do
+      let(:config) { super.merge('batch' => false) }
+
+      it 'publishes to SQS' do
+        subject.multi_receive_encoded(sample_events)
+        expect(receive_all_messages(@queue_url).count).to eq(sample_events.count)
+      end
+    end
+
+    context 'with batching enabled' do
+      let(:config) { super.merge('batch' => true) }
+
+      it 'publishes to SQS' do
+        subject.multi_receive_encoded(sample_events)
+        expect(receive_all_messages(@queue_url).count).to eq(sample_events.count)
+      end
+    end
+  end
+end

--- a/spec/outputs/sqs_spec.rb
+++ b/spec/outputs/sqs_spec.rb
@@ -1,5 +1,0 @@
-# encoding: utf-8
-require "logstash/devutils/rspec/spec_helper"
-require 'logstash/outputs/sqs'
-
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+require 'aws-sdk'
+require 'logstash/devutils/rspec/spec_helper'
+require 'logstash/outputs/sqs'
+require_relative 'supports/helpers'
+
+LogStash::Logging::Logger::configure_logging('debug') if ENV['DEBUG']

--- a/spec/supports/helpers.rb
+++ b/spec/supports/helpers.rb
@@ -1,0 +1,20 @@
+require 'aws-sdk'
+
+# Retrieve all available messages from the specified queue.
+#
+# Rather than utilizing `Aws::SQS::QueuePoller` directly in order to poll an
+# SQS queue for messages, this method retrieves and returns all messages that
+# are able to be received from the specified SQS queue.
+def receive_all_messages(queue_url, options = {})
+  options[:idle_timeout] ||= 0
+  options[:max_number_of_messages] ||= 10
+
+  messages = []
+  poller = Aws::SQS::QueuePoller.new(queue_url, options)
+
+  poller.poll do |received_messages|
+    messages.concat(received_messages)
+  end
+
+  messages
+end

--- a/spec/unit/outputs/sqs_spec.rb
+++ b/spec/unit/outputs/sqs_spec.rb
@@ -1,0 +1,245 @@
+# encoding: utf-8
+
+require_relative '../../spec_helper'
+require 'logstash/errors'
+require 'logstash/event'
+require 'logstash/json'
+
+describe LogStash::Outputs::SQS do
+  let(:config) do
+    {
+      'queue' => queue_name,
+      'region' => region,
+    }
+  end
+  let(:queue_name) { 'my-sqs-queue' }
+  let(:queue_url) { "https://sqs.#{region}.amazonaws.com/123456789012/#{queue_name}" }
+  let(:region) { 'us-east-1' }
+
+  let(:sqs) { Aws::SQS::Client.new(:stub_responses => true) }
+  subject { described_class.new(config) }
+
+  describe '#register' do
+    context 'with a batch size that is too large' do
+      let(:config) { super.merge('batch_events' => 100) }
+
+      before do
+        allow(Aws::SQS::Client).to receive(:new).and_return(sqs)
+      end
+
+      it 'raises a configuration error' do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+
+    context 'with a batch size that is too small' do
+      let(:config) { super.merge('batch_events' => 0) }
+
+      before do
+        allow(Aws::SQS::Client).to receive(:new).and_return(sqs)
+      end
+
+      it 'raises a configuration error' do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+
+    context 'without a queue' do
+      let(:config) { Hash.new }
+
+      it 'raises a configuration error' do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+
+    context 'with a nonexistent queue' do
+      before do
+        expect(Aws::SQS::Client).to receive(:new).and_return(sqs)
+        expect(sqs).to receive(:get_queue_url).with(:queue_name => queue_name) do
+          raise Aws::SQS::Errors::NonExistentQueue.new(nil, 'The specified queue does not exist for this wsdl version.')
+        end
+      end
+
+      it 'raises a configuration error' do
+        expect { subject.register }.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+
+    context 'with a valid queue' do
+      before do
+        expect(Aws::SQS::Client).to receive(:new).and_return(sqs)
+        expect(sqs).to receive(:get_queue_url).with(:queue_name => queue_name).and_return(:queue_url => queue_url)
+      end
+
+      it 'does not raise an error' do
+        expect { subject.register }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#multi_receive_encoded' do
+    before do
+      expect(Aws::SQS::Client).to receive(:new).and_return(sqs)
+      expect(sqs).to receive(:get_queue_url).with(:queue_name => queue_name).and_return(:queue_url => queue_url)
+      subject.register
+    end
+
+    after do
+      subject.close
+    end
+
+    let(:sample_count) { 10 }
+    let(:sample_event) { LogStash::Event.new('message' => 'This is a message') }
+    let(:sample_events) do
+      sample_count.times.map do
+        [sample_event, LogStash::Json.dump(sample_event)]
+      end
+    end
+
+    context 'with batching disabled' do
+      let(:config) { super.merge('batch' => false) }
+
+      it 'should call send_message' do
+        sample_event_encoded = LogStash::Json.dump(sample_event)
+
+        expect(sqs).to receive(:send_message).with(:queue_url => queue_url, :message_body => sample_event_encoded).exactly(sample_count).times
+        subject.multi_receive_encoded(sample_events)
+      end
+
+      it 'should not call send_message_batch' do
+        expect(sqs).not_to receive(:send_message_batch)
+        subject.multi_receive_encoded(sample_events)
+      end
+    end
+
+    context 'with batching enabled' do
+      let(:batch_events) { 3 }
+      let(:config) do
+        super.merge({
+          'batch' => true,
+          'batch_events' => batch_events,
+        })
+      end
+
+      let(:sample_batches) do
+        sample_events.each_slice(batch_events).each_with_index.map do |sample_batch, batch_index|
+          sample_batch.each_with_index.map do |encoded_event, index|
+            event, encoded = encoded_event
+            {
+              :id => (batch_index * batch_events + index).to_s,
+              :message_body => encoded,
+            }
+          end
+        end
+      end
+
+      it 'should call send_message_batch' do
+        expect(sqs).to receive(:send_message_batch).at_least(:once)
+        subject.multi_receive_encoded(sample_events)
+      end
+
+      it 'should batch events' do
+        sample_batches.each do |batch_entries|
+          expect(sqs).to receive(:send_message_batch).with(:queue_url => queue_url, :entries => batch_entries)
+        end
+
+        subject.multi_receive_encoded(sample_events)
+      end
+    end
+
+    context 'with empty payload' do
+      let(:sample_count) { 0 }
+
+      it 'does not raise an error' do
+        expect { subject.multi_receive_encoded(sample_events) }.not_to raise_error
+      end
+
+      it 'should not send any messages' do
+        expect(sqs).not_to receive(:send_message)
+        expect(sqs).not_to receive(:send_message_batch)
+        subject.multi_receive_encoded(sample_events)
+      end
+    end
+
+    context 'with event exceeding maximum size' do
+      let(:config) { super.merge('message_max_size' => message_max_size) }
+      let(:message_max_size) { 1024 }
+
+      let(:sample_count) { 1 }
+      let(:sample_event) { LogStash::Event.new('message' => '.' * message_max_size) }
+
+      it 'should drop event' do
+        expect(sqs).not_to receive(:send_message)
+        expect(sqs).not_to receive(:send_message_batch)
+        subject.multi_receive_encoded(sample_events)
+      end
+    end
+
+
+
+    context 'with large batch' do
+      let(:batch_events) { 4 }
+      let(:config) do
+        super.merge({
+          'batch_events' => batch_events,
+          'message_max_size' => message_max_size,
+        })
+      end
+      let(:message_max_size) { 1024 }
+
+      let(:sample_events) do
+        # This is the overhead associating with transmitting each message. The
+        # overhead is caused by metadata (such as the `message` field name and
+        # the `@timestamp` field) as well as additional characters as a result
+        # of encoding the event.
+        overhead = 69
+
+        events = [
+          LogStash::Event.new('message' => 'a' * (0.6 * message_max_size - overhead)),
+          LogStash::Event.new('message' => 'b' * (0.5 * message_max_size - overhead)),
+          LogStash::Event.new('message' => 'c' * (0.5 * message_max_size - overhead)),
+          LogStash::Event.new('message' => 'd' * (0.4 * message_max_size - overhead)),
+        ]
+
+        events.map do |event|
+          [event, LogStash::Json.dump(event)]
+        end
+      end
+
+      let(:sample_batches) do
+        [
+          [
+            {
+              :id => '0',
+              :message_body => sample_events[0][1],
+            },
+          ],
+          [
+            {
+              :id => '1',
+              :message_body => sample_events[1][1],
+            },
+            {
+              :id => '2',
+              :message_body => sample_events[2][1],
+            },
+          ],
+          [
+            {
+              :id => '3',
+              :message_body => sample_events[3][1],
+            },
+          ],
+        ]
+      end
+
+      it 'should split events into smaller batches' do
+        sample_batches.each do |entries|
+          expect(sqs).to receive(:send_message_batch).with(:queue_url => queue_url, :entries => entries)
+        end
+
+        subject.multi_receive_encoded(sample_events)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a fairly major rewrite of the plugin, including the following changes:

  - Add unit and integration tests.
  - Adjust the sample IAM policy in the documentation, removing actions which are not actually required by the plugin. Specifically, the following actions are not required: `sqs:ChangeMessageVisibility`, `sqs:ChangeMessageVisibilityBatch`, `sqs:GetQueueAttributes` and `sqs:ListQueues`.
  - Dynamically adjust the batch message size. SQS allows up to 10 messages to be published in a single batch, however the total size of the batch is limited to 256KiB (see [Limits in Amazon SQS](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/limits-messages.html)). This plugin will now dynamically adjust the number of events included in each batch to ensure that the total batch size does not exceed `message_max_size`. Note that any single messages which exceeds the 256KiB size limit will be dropped.
  - Move to the new concurrency model, `:shared`.
  - The `batch_timeout` parameter has been deprecated because it no longer has any effect.
  - The individual (non-batch) mode of operation (i.e. `batch => false`) has been deprecated. Batch mode is vastly more performant and we do not believe that there are any use cases which require non-batch mode. You can emulate non-batch mode by setting `batch_events => 1`, although this will call `sqs:SendMessageBatch` with a batch size of 1 rather than calling `sqs:SendMessage`.
  - The plugin now implements `#multi_receive_encoded` and no longer uses `Stud::Buffer`.
  - Update the AWS SDK to version 2.