### PR TITLE
Remove comments causing docgen issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+  - Docs: Fix doc generation issue by removing extraneous comments.
+
 ## 4.0.0
   - Add unit and integration tests.
   - Adjust the sample IAM policy in the documentation, removing actions which are not actually required by the plugin. Specifically, the following actions are not required: `sqs:ChangeMessageVisibility`, `sqs:ChangeMessageVisibilityBatch`, `sqs:GetQueueAttributes` and `sqs:ListQueues`.

--- a/lib/logstash/outputs/sqs.rb
+++ b/lib/logstash/outputs/sqs.rb
@@ -7,10 +7,6 @@ require 'logstash/outputs/base'
 require 'logstash/outputs/sqs/patch'
 require 'logstash/plugin_mixins/aws_config'
 
-# Forcibly load all modules marked to be lazily loaded.
-#
-# It is recommended that this is called prior to launching threads. See
-# https://aws.amazon.com/blogs/developer/threading-with-the-aws-sdk-for-ruby/.
 Aws.eager_autoload!
 
 # Push events to an Amazon Web Services (AWS) Simple Queue Service (SQS) queue.

--- a/logstash-output-sqs.gemspec
+++ b/logstash-output-sqs.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-sqs'
-  s.version         = '4.0.0'
+  s.version         = '4.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to an Amazon Web Services Simple Queue Service (SQS) queue."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Removes comments in order to fix the docgen issue described in elastic/logstash#6692 (comment).
